### PR TITLE
Rota de configurações ajustada

### DIFF
--- a/src/app/features/home/menu-cards.ts
+++ b/src/app/features/home/menu-cards.ts
@@ -67,7 +67,7 @@ export const ALL_MENU_CARDS: MenuCard[] = [
     icon: 'bi bi-gear-fill',
     title: 'Configurações',
     text: 'Ajuste configurações do sistema.',
-    link: '/configuracoes',
+    link: '/app/admin/configuracoes',
     roles: ['ROLE_ADMIN']
   }
 ];


### PR DESCRIPTION
#25 
[Screencast from 2025-08-10 18-37-12.webm](https://github.com/user-attachments/assets/8be33291-ce77-42eb-adf6-71b896279127)


Reconfigurei a rota de configurações direcionando ao modal já existente. Agora, ao clicar em "Configurações" no menu de Acesso Rápido, o sistema redireciona à tela de confgurações.