### PR TITLE
BR-013 - Alteração ngOnInit para ngAfterView

### DIFF
--- a/src/app/features/gerenciarusuarios/gerenciarusuarios.ts
+++ b/src/app/features/gerenciarusuarios/gerenciarusuarios.ts
@@ -8,6 +8,7 @@ import { FormsModule } from '@angular/forms';
 import { AlertComponent } from '../../shared/alert/alert';
 import { ModalConfirmacaoComponent } from '../../shared/modal-confirmacao/modal-confirmacao';
 import { ProfileSwitcherComponent } from '../../shared/profile-switcher/profile-switcher';
+import { ChangeDetectorRef } from '@angular/core';
 
 declare var bootstrap: any;
 
@@ -60,17 +61,20 @@ export class Gerenciarusuarios implements OnInit {
 
   constructor(
     public authService: AuthService,
-    private usuarioService: UsuarioService
+    private usuarioService: UsuarioService,
+    private cdr: ChangeDetectorRef
   ) {}
 
    ngOnInit(): void {
     this.carregarUsuarios();
-
-    const modalElement = document.getElementById('editarUsuarioModal');
-    if (modalElement) {
-      this.editarUsuarioModal = new bootstrap.Modal(modalElement);
-    }
   }
+
+  ngAfterViewInit(): void {
+  const modalElement = document.getElementById('editarUsuarioModal');
+  if (modalElement) {
+    this.editarUsuarioModal = new bootstrap.Modal(modalElement);
+  }
+}
 
   carregarUsuarios() {
     this.usuarioService.listarTodosComDetalhes().subscribe({
@@ -235,11 +239,18 @@ export class Gerenciarusuarios implements OnInit {
     });
   }
 
-  abrirModalEditar(usuario: Usuario) {
-    if (!this.authService.isRoleActiveOrHigher('ROLE_ADMIN')) return;
-    this.usuarioParaEditar = JSON.parse(JSON.stringify(usuario));
-    this.editarUsuarioModal.show();
-  }
+
+
+abrirModalEditar(usuario: Usuario) {
+  if (!this.authService.isRoleActiveOrHigher('ROLE_ADMIN')) return;
+
+  this.usuarioParaEditar = { ...usuario };
+
+  // Força o Angular a renderizar os campos antes de mostrar o modal
+  this.cdr.detectChanges();
+
+  this.editarUsuarioModal.show();
+}
 
   salvarEdicao() {
     this.usuarioService.atualizarUsuario(this.usuarioParaEditar).subscribe({


### PR DESCRIPTION
#13 
[Screencast from 2025-08-11 22-35-04.webm](https://github.com/user-attachments/assets/bf46481a-f3b1-43e7-97f3-94f02d71cfbd)


Realizei alterações no método declarado em NgOnInit( O que estava possivelmente ocasionando no modal não carregar), coloquei este mesmo método dentro do escopo de ngAfterView, onde o mesmo renderiza e carrega, e depois mudei o método que continha o Stringify, importei o CDR  Change Detector, que força o angular detectar as mudanças  para salvar as informações editadas. Tive apenas um erro onde nas primeiras vezes, as informações não eram editadas, mas acabou funcionando depois.

@matheus-phelipe 
@pemvdev 